### PR TITLE
Add Issue template for Component Library

### DIFF
--- a/.github/ISSUE_TEMPLATE/component-library.md
+++ b/.github/ISSUE_TEMPLATE/component-library.md
@@ -1,0 +1,41 @@
+---
+name: Component Library
+about: This template is for adding new components to the component library package.
+title: feature/component-library-{name}
+labels: haus-components, sage
+assignees: ''
+
+---
+
+# Overview
+
+Describe the component being added
+
+## Details
+
+Specific details about the component. 
+Name: `<ComponentName />`
+
+### Spec questions
+
+Include any specific questions about the Spec here that may require further input or investgiation
+
+- Question 1
+- Question 2
+
+#### States
+
+- Include a description of different states 
+
+#### Props
+
+- Include the props that have been identified in the spec
+
+## Resources/Design
+
+- Include a link to a reference, such as the Figma node
+
+## Deliverable
+
+- Code/PR
+- Storybook story and working build for deployment (run the build command before submitting the PR)


### PR DESCRIPTION
This PR adds an issue template that we can use for Sage Component Library cards