### PR TITLE
Component Library: Updating the linting to ignore CSS

### DIFF
--- a/libs/ui/.eslintrc.json
+++ b/libs/ui/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "extends": ["plugin:@nrwl/nx/react", "../../.eslintrc.json"],
-  "ignorePatterns": ["!**/*"],
+  "ignorePatterns": ["!**/*", "**/*.css"],
   "overrides": [
     {
       "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],


### PR DESCRIPTION
## GitHub Issue

N/a

## Changes

This ignores all `.css` files in our component library to resolve the linting error in our CI -- we noticed this in #55

Running `nx run ui:lint` works locally with this change. We'll need to see if our CI is fixed by this or if we'll need to address this at the global level (the root `.eslintrc.json` config). We may need to ignore CSS at that level instead, but we can try this first.

## Packages Added

N/A

## Checks

Before making your PR, please check the following:

- [x] Critical lint errors are resolved
- [x] App runs locally
- [x] App builds locally (run the build command for *any impacted package* and check for any errors before the PR)
