### PR TITLE
Refactor/network and rpc as props

### DIFF
--- a/apps/summon-app/src/app/constants.ts
+++ b/apps/summon-app/src/app/constants.ts
@@ -1,0 +1,27 @@
+// FOR DEMONSTRATIOn
+export const limitedNetworkTest = {
+  '0x1': {
+    chainId: '0x1',
+    networkId: 1,
+    name: 'Mainnet',
+    symbol: 'ETH',
+    rpc: `https://${import.meta.env.VITE_RIVET_KEY}.eth.rpc.rivet.cloud/`,
+    explorer: 'https://etherscan.io',
+  },
+  '0x4': {
+    chainId: '0x4',
+    networkId: 4,
+    name: 'Rinkeby',
+    symbol: 'ETH',
+    rpc: `https://${import.meta.env.VITE_RIVET_KEY}.rinkeby.rpc.rivet.cloud/`,
+    explorer: 'https://rinkeby.etherscan.io',
+  },
+  '0x2a': {
+    chainId: '0x2a',
+    networkId: 42,
+    name: 'Kovan',
+    symbol: 'ETH',
+    rpc: `https://kovan.infura.io/v3/${import.meta.env.VITE_INFURA_PROJECT_ID}`,
+    explorer: 'https://kovan.etherscan.io',
+  },
+};

--- a/apps/summon-app/src/main.tsx
+++ b/apps/summon-app/src/main.tsx
@@ -5,6 +5,8 @@ import * as ReactDOM from 'react-dom';
 import { BrowserRouter } from 'react-router-dom';
 
 import App from './app/App';
+// FOR DEMONSTRATIOn
+// import { limitedNetworkTest } from './app/constants';
 
 ReactDOM.render(
   <StrictMode>

--- a/libs/common-utilities/src/constants/chainData.ts
+++ b/libs/common-utilities/src/constants/chainData.ts
@@ -99,3 +99,18 @@ export const addKeychain = (
     };
   }, {});
 };
+
+export const extractKeychain = (
+  networkList: Keychain<NetworkType>,
+  property: string
+) => {
+  return Object.values(networkList).reduce((acc, network) => {
+    const { chainId } = network;
+    return network[property]
+      ? {
+          ...acc,
+          [chainId]: network[property],
+        }
+      : acc;
+  }, {});
+};

--- a/libs/daohaus-connect-feature/src/HausConnectContext.tsx
+++ b/libs/daohaus-connect-feature/src/HausConnectContext.tsx
@@ -1,5 +1,3 @@
-import { isValidNetwork } from '@daohaus/common-utilities';
-
 import {
   createContext,
   ReactNode,
@@ -9,6 +7,8 @@ import {
   useMemo,
   useState,
 } from 'react';
+
+import { isValidNetwork } from '@daohaus/common-utilities';
 
 import {
   getModal,
@@ -101,12 +101,18 @@ export const HausConnectProvider = ({
   useEffect(() => {
     let shouldUpdate = true;
     if (address && isConnected) {
-      loadProfile({ address, setProfile, setProfileLoading, shouldUpdate });
+      loadProfile({
+        address,
+        setProfile,
+        setProfileLoading,
+        shouldUpdate,
+        networks,
+      });
     }
     return () => {
       shouldUpdate = false;
     };
-  }, [address, isConnected]);
+  }, [address, isConnected, networks]);
 
   const switchNetwork = async (_chainId: string | number) => {
     handleSwitchNetwork(_chainId, networks);

--- a/libs/daohaus-connect-feature/src/utils/contextHelpers.ts
+++ b/libs/daohaus-connect-feature/src/utils/contextHelpers.ts
@@ -1,8 +1,12 @@
-import { isValidNetwork, ReactSetter } from '@daohaus/common-utilities';
+import {
+  extractKeychain,
+  isValidNetwork,
+  ReactSetter,
+} from '@daohaus/common-utilities';
 import { Haus } from '@daohaus/dao-data';
 import { SafeAppWeb3Modal } from '@gnosis.pm/safe-apps-web3modal';
 import { providers } from 'ethers';
-import { TEMPORARY_RPC, truncateAddress } from './common';
+import { truncateAddress } from './common';
 
 import { switchChainOnMetaMask } from './metamask';
 import {
@@ -111,15 +115,19 @@ export const loadProfile = async ({
   setProfile,
   setProfileLoading,
   shouldUpdate,
+  networks,
 }: {
   address: string;
   setProfile: ReactSetter<UserProfile>;
   setProfileLoading: ReactSetter<boolean>;
   shouldUpdate: boolean;
+  networks: NetworkConfigs;
 }) => {
   try {
     setProfileLoading(true);
-    const haus = Haus.create(TEMPORARY_RPC);
+    const rpcs = extractKeychain(networks, 'rpc');
+
+    const haus = Haus.create(rpcs);
     const profile = await haus.profile.get(address);
 
     if (profile && shouldUpdate) {


### PR DESCRIPTION
## GitHub Issue

https://github.com/orgs/HausDAO/projects/3/views/3?filterQuery=label%3A%22daohaus-connect%22

## Changes

- Enables community developers to add their own rpc vars
- Uses ours by default
- Since RPC key are stored in .env community devs will not have access to our keys. 
- Tested narrowing networks through props.  

## Packages Added

NA

## Checks

Before making your PR, please check the following:

- [x] Critical lint errors are resolved
- [x] App runs locally
- [x] App builds locally (run the build command for *any impacted package* and check for any errors before the PR)
