### PR TITLE
fix/fix-table-types

### DIFF
--- a/apps/hub-app/src/components/DaoTable.tsx
+++ b/apps/hub-app/src/components/DaoTable.tsx
@@ -63,8 +63,7 @@ const FirstCell = styled.p`
   align-items: center;
 `;
 
-export const DataTable = ({ daoData }: IDaoTableData) => {
-  console.log('daoData', daoData);
+export const DaoTable = ({ daoData }: IDaoTableData) => {
   const tableData = React.useMemo<ITransformedMembership[]>(
     () =>
       daoData.map((dao: ITransformedMembership) => ({

--- a/apps/hub-app/src/components/HomeDashboard.tsx
+++ b/apps/hub-app/src/components/HomeDashboard.tsx
@@ -4,7 +4,7 @@ import { MouseEvent, useState } from 'react';
 import styled from 'styled-components';
 import { ListType } from '../utils/appSpecificTypes';
 import { DaoCards } from './DaoCards';
-import { DataTable } from './Table';
+import { DaoTable } from './DaoTable';
 import TableControl from './TableControl';
 
 // Refactored this to be a component that we might be able to reuse
@@ -115,7 +115,7 @@ const Desktop = ({
   return (
     <>
       {listType === 'cards' && <DaoCards daoData={daoData} />}
-      {listType === 'table' && <DataTable daoData={daoData} />}
+      {listType === 'table' && <DaoTable daoData={daoData} />}
     </>
   );
 };

--- a/apps/hub-app/src/components/HomeDashboard.tsx
+++ b/apps/hub-app/src/components/HomeDashboard.tsx
@@ -2,7 +2,6 @@ import { ITransformedMembership } from '@daohaus/dao-data';
 import { ParMd, Spinner, useBreakpoint, widthQuery } from '@daohaus/ui';
 import { MouseEvent, useState } from 'react';
 import styled from 'styled-components';
-
 import { ListType } from '../utils/appSpecificTypes';
 import { DaoCards } from './DaoCards';
 import { DataTable } from './Table';
@@ -16,8 +15,8 @@ const Body = styled.div`
 `;
 
 type DashProps = {
-  // daoData: ITransformedMembership[] | any;
-  daoData: any;
+  daoData: ITransformedMembership[];
+  // daoData: any;
   filterNetworks: Record<string, string>;
   toggleNetworkFilter: (event: MouseEvent<HTMLButtonElement>) => void;
   filterDelegate: string;

--- a/apps/hub-app/src/components/Table.tsx
+++ b/apps/hub-app/src/components/Table.tsx
@@ -1,25 +1,26 @@
 import React from 'react';
-import { Keychain } from '@daohaus/common-utilities';
+import { ITransformedMembership } from '@daohaus/dao-data';
 import { useTable, Column } from 'react-table';
 import styled from 'styled-components';
 import { indigoDark } from '@radix-ui/colors';
 import { Avatar } from '@daohaus/ui';
 import { BiGhost } from 'react-icons/bi';
 
-interface DaoData {
-  name: string;
-  activeProposalCount: number | string;
-  activeMemberCount: string;
-  votingPower: number;
-  networkId?: keyof Keychain;
-  delegate: string | undefined;
-  memberAddress?: string;
-  fiatTotal: number;
-  totalProposalCount?: string;
-}
+// interface DaoData {
+//   name: string;
+//   activeProposalCount: number | string;
+//   activeMemberCount: string;
+//   votingPower: number;
+//   networkId?: keyof Keychain;
+//   delegate: string | undefined;
+//   memberAddress?: string;
+//   fiatTotal: number;
+//   totalProposalCount?: string;
+// }
 
 interface IDaoTableData {
-  daoData: DaoData[] | any;
+  // daoData: DaoData[];
+  daoData: ITransformedMembership[];
 }
 
 const Table = styled.table`
@@ -63,9 +64,10 @@ const FirstCell = styled.p`
 `;
 
 export const DataTable = ({ daoData }: IDaoTableData) => {
-  const tableData = React.useMemo<DaoData[]>(
+  console.log('daoData', daoData);
+  const tableData = React.useMemo<ITransformedMembership[]>(
     () =>
-      daoData.map((dao: DaoData) => ({
+      daoData.map((dao: ITransformedMembership) => ({
         name: dao.name,
         activeProposalCount: dao.activeProposalCount,
         fiatTotal: dao.fiatTotal,
@@ -73,15 +75,21 @@ export const DataTable = ({ daoData }: IDaoTableData) => {
         votingPower: dao.votingPower,
         networkId: dao.networkId,
         delegate: dao.delegate === undefined ? 'No Delegate' : dao.delegate,
+        memberAddress: dao.memberAddress,
+        safeAddress: dao.safeAddress,
+        dao: dao.dao,
+        isDelegate: dao.isDelegate,
+        totalProposalCount: dao.totalProposalCount,
+        contractType: dao.contractType,
       })),
     [daoData]
   );
 
-  const exampleColumns = React.useMemo<Column<DaoData>[]>(
+  const exampleColumns = React.useMemo<Column<ITransformedMembership>[]>(
     () => [
       {
         accessor: 'name', // accessor is the "key" in the data
-        Cell: ({ value }: { value: string | number }) => {
+        Cell: ({ value }: { value: string | undefined }) => {
           return (
             <FirstCell>
               <Avatar size="sm" fallback={<BiGhost />} />


### PR DESCRIPTION
## GitHub Issue

https://github.com/HausDAO/daohaus-monorepo/issues/353

## Changes

- Removes the `any` types and uses the `ITransformedMembership` type used by `DaoCard`
- Renames `Table` to `DaoTable` and `DataTable` export to `DaoTable` to be more consistent with `DaoCard`

## Packages Added

Brief list of any packages added, and if folks need to rerun `yarn install` to run locally

## Checks

Before making your PR, please check the following:

- [ ] Critical lint errors are resolved
- [ ] App runs locally
- [ ] App builds locally (run the build command for *any impacted package* and check for any errors before the PR)
