### PR TITLE
fixing doc display name from <[object Object]> to displayName

### DIFF
--- a/libs/ui/src/components/atoms/Card/Card.stories.tsx
+++ b/libs/ui/src/components/atoms/Card/Card.stories.tsx
@@ -6,6 +6,9 @@ export default {
   component: Card,
 } as ComponentMeta<typeof Card>;
 
+// Setting displayName manually since Storybook displays it as [Object, object]
+Card.displayName = 'Card';
+
 const Template: ComponentStory<typeof Card> = (args) => {
   return <Card>{args.children}</Card>;
 };

--- a/libs/ui/src/components/atoms/Checkbox/Checkbox.stories.tsx
+++ b/libs/ui/src/components/atoms/Checkbox/Checkbox.stories.tsx
@@ -8,6 +8,9 @@ export default {
   component: Checkbox,
 } as ComponentMeta<typeof Checkbox>;
 
+// Setting displayName manually since Storybook displays it as [Object, object]
+Checkbox.displayName = 'Checkbox';
+
 const Template: ComponentStory<typeof Checkbox> = (args) => {
   const [checked, setChecked] = useState(args.defaultChecked);
 

--- a/libs/ui/src/components/atoms/Radio/Radio.stories.tsx
+++ b/libs/ui/src/components/atoms/Radio/Radio.stories.tsx
@@ -6,6 +6,9 @@ export default {
   component: Radio,
 } as ComponentMeta<typeof Radio>;
 
+// Setting displayName manually since Storybook displays it as [Object, object]
+Radio.displayName = 'Radio';
+
 const Template: ComponentStory<typeof Radio> = (args) => <Radio {...args} />;
 
 export const AtomRadio = Template.bind({});

--- a/libs/ui/src/components/atoms/Switch/Switch.stories.tsx
+++ b/libs/ui/src/components/atoms/Switch/Switch.stories.tsx
@@ -6,6 +6,9 @@ export default {
   component: Switch,
 } as ComponentMeta<typeof Switch>;
 
+// Setting displayName manually since Storybook displays it as [Object, object]
+Switch.displayName = 'Switch';
+
 const Template: ComponentStory<typeof Switch> = (args) => <Switch {...args} />;
 
 export const AtomSwitch = Template.bind({});


### PR DESCRIPTION
## GitHub Issue

N/A

## Changes

was reviewing the v3 repo and caught a few of the StoryBook examples without a display name, casuing them to display as `<[object Object]>`

## Checks

Before making your PR, please check the following:

- [X] Critical lint errors are resolved
- [X] App runs locally
- [X] App builds locally (run the build command for *any impacted package* and check for any errors before the PR)

# Details

![Screen Shot 2022-07-11 at 4 44 59 PM](https://user-images.githubusercontent.com/5998100/178372976-1cd595dc-0eb8-45c1-9379-5cd0a1992d38.png)
