### PR TITLE
adding sensible defaults to package.json for npm to read

### DIFF
--- a/libs/abi-utilities/package.json
+++ b/libs/abi-utilities/package.json
@@ -1,5 +1,18 @@
 {
   "name": "@daohaus/abi-utilities",
   "version": "0.0.2",
-  "type": "commonjs"
+  "type": "commonjs",
+  "homepage": "https://github.com/HausDAO/daohaus-monorepo#readme",
+  "issues": "https://github.com/HausDAO/daohaus-monorepo/issues?q=is%3Aissue+is%3Aopen",
+  "license": "MIT",
+  "keywords": [
+    "daohaus",
+    "abi-utilities",
+    "daohaus abi"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:HausDAO/daohaus-monorepo.git",
+    "directory": "libs/abi-utilities"
+  }
 }

--- a/libs/baal-contract-service/package.json
+++ b/libs/baal-contract-service/package.json
@@ -1,5 +1,18 @@
 {
   "name": "@daohaus/baal-contract-service",
   "version": "0.0.1",
-  "type": "commonjs"
+  "type": "commonjs",
+  "homepage": "https://github.com/HausDAO/daohaus-monorepo#readme",
+  "issues": "https://github.com/HausDAO/daohaus-monorepo/issues?q=is%3Aissue+is%3Aopen",
+  "license": "MIT",
+  "keywords": [
+    "daohaus",
+    "baal-contract-service",
+    "daohaus baal"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:HausDAO/daohaus-monorepo.git",
+    "directory": "libs/baal-contract-service"
+  }
 }

--- a/libs/common-utilities/package.json
+++ b/libs/common-utilities/package.json
@@ -1,5 +1,19 @@
 {
   "name": "@daohaus/common-utilities",
   "version": "0.0.4",
-  "type": "commonjs"
+  "type": "commonjs",
+  "homepage": "https://github.com/HausDAO/daohaus-monorepo#readme",
+  "issues": "https://github.com/HausDAO/daohaus-monorepo/issues?q=is%3Aissue+is%3Aopen",
+  "license": "MIT",
+  "keywords": [
+    "daohaus",
+    "common-utilities",
+    "daohaus utils",
+    "daohaus utilities"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:HausDAO/daohaus-monorepo.git",
+    "directory": "libs/common-utilities"
+  }
 }

--- a/libs/dao-data/package.json
+++ b/libs/dao-data/package.json
@@ -1,5 +1,18 @@
 {
   "name": "@daohaus/dao-data",
   "version": "0.0.5",
-  "type": "commonjs"
+  "type": "commonjs",
+  "homepage": "https://github.com/HausDAO/daohaus-monorepo#readme",
+  "issues": "https://github.com/HausDAO/daohaus-monorepo/issues?q=is%3Aissue+is%3Aopen",
+  "license": "MIT",
+  "keywords": [
+    "daohaus",
+    "dao-data",
+    "daohaus data"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:HausDAO/daohaus-monorepo.git",
+    "directory": "libs/dao-data"
+  }
 }

--- a/libs/daohaus-connect-feature/package.json
+++ b/libs/daohaus-connect-feature/package.json
@@ -3,6 +3,19 @@
   "version": "0.0.5",
   "main": "./daohaus-connect-feature.umd.js",
   "module": "./daohaus-connect-feature.es.js",
+  "homepage": "https://github.com/HausDAO/daohaus-monorepo#readme",
+  "issues": "https://github.com/HausDAO/daohaus-monorepo/issues?q=is%3Aissue+is%3Aopen",
+  "license": "MIT",
+  "keywords": [
+    "daohaus",
+    "daohaus-connect-feature",
+    "daohaus connect"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:HausDAO/daohaus-monorepo.git",
+    "directory": "libs/daohaus-connect-feature"
+  },
   "exports": {
     ".": {
       "import": "./daohaus-connect-feature.es.js",

--- a/libs/tx-builder-feature/package.json
+++ b/libs/tx-builder-feature/package.json
@@ -3,6 +3,19 @@
   "version": "0.0.4",
   "main": "./tx-builder-feature.umd.js",
   "module": "./tx-builder-feature.es.js",
+  "homepage": "https://github.com/HausDAO/daohaus-monorepo#readme",
+  "issues": "https://github.com/HausDAO/daohaus-monorepo/issues?q=is%3Aissue+is%3Aopen",
+  "license": "MIT",
+  "keywords": [
+    "daohaus",
+    "tx-builder-feature",
+    "daohaus transaction builder"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:HausDAO/daohaus-monorepo.git",
+    "directory": "libs/tx-builder-feature"
+  },
   "exports": {
     ".": {
       "import": "./tx-builder-feature.es.js",

--- a/libs/ui/package.json
+++ b/libs/ui/package.json
@@ -3,6 +3,18 @@
   "version": "0.0.8",
   "main": "./ui.umd.js",
   "module": "./ui.es.js",
+  "homepage": "https://github.com/HausDAO/daohaus-monorepo#readme",
+  "issues": "https://github.com/HausDAO/daohaus-monorepo/issues?q=is%3Aissue+is%3Aopen+label%3Acore-ui",
+  "license": "MIT",
+  "keywords": [
+    "daohaus",
+    "daohaus ui"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:HausDAO/daohaus-monorepo.git",
+    "directory": "libs/ui"
+  },
   "exports": {
     ".": {
       "import": "./ui.es.js",


### PR DESCRIPTION
## GitHub Issue

fixes https://github.com/HausDAO/daohaus-monorepo/issues/431

## Changes

I noticed our npm packages listings do not have much config details being read for our libs. Adding some basic details package.json so they display in npm and github based on reading package.json

 if this is not warranted yet, feel free to close the pr and issue

## Packages Added

N/A

## Checks

Before making your PR, please check the following:

- [X] Critical lint errors are resolved
- [X] App runs locally
- [X] App builds locally (run the build command for *any impacted package* and check for any errors before the PR)

# Details

Current dao haus lib packages:

![Screen Shot 2022-07-13 at 2 46 05 PM](https://user-images.githubusercontent.com/5998100/178834851-25caa0b6-4d6f-46fc-84cc-4abb26d40b69.png)


React.js npm (notice Licnese field, issues, homepage, etc):

![Screen Shot 2022-07-13 at 3 05 21 PM](https://user-images.githubusercontent.com/5998100/178834706-d20d439a-ffa1-4895-9847-1ac9b0df6267.png)