### PR TITLE
bumping packages that were published pre revert last week - causing f…

### DIFF
--- a/libs/common-utilities/package.json
+++ b/libs/common-utilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daohaus/common-utilities",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "type": "commonjs",
   "homepage": "https://github.com/HausDAO/daohaus-monorepo#readme",
   "issues": "https://github.com/HausDAO/daohaus-monorepo/issues?q=is%3Aissue+is%3Aopen",

--- a/libs/dao-data/package.json
+++ b/libs/dao-data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daohaus/dao-data",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "type": "commonjs",
   "homepage": "https://github.com/HausDAO/daohaus-monorepo#readme",
   "issues": "https://github.com/HausDAO/daohaus-monorepo/issues?q=is%3Aissue+is%3Aopen",

--- a/libs/tx-builder-feature/package.json
+++ b/libs/tx-builder-feature/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daohaus/tx-builder-feature",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "main": "./tx-builder-feature.umd.js",
   "module": "./tx-builder-feature.es.js",
   "homepage": "https://github.com/HausDAO/daohaus-monorepo#readme",


### PR DESCRIPTION
…ialures with package publishing

## GitHub Issue

https://github.com/HausDAO/daohaus-monorepo/issues/459

## Description

still some lingering issues with last weeks revert on master and remerge, this time the npm packages did not publish because the packages were published before the revert. When we reverted and remerged the previous changes, the attempt to republish the packages failed because those versions referenced were already published.

https://github.com/HausDAO/daohaus-monorepo/runs/7347218124?check_suite_focus=true#step:10:345
`You cannot publish over the previously published versions x.x.x`

## Changes

rebumping the versions for the packages that were published pre revert should solve this issue.

## Checks

Before making your PR, please check the following:

- [ ] Critical lint errors are resolved
- [ ] App runs locally
- [ ] App builds locally (run the build command for *any impacted package* and check for any errors before the PR)

# Details

![Screen Shot 2022-07-18 at 12 33 44 PM](https://user-images.githubusercontent.com/5998100/179590951-1ea76741-6854-4071-b9e9-efcde6f34c02.png)

![Screen Shot 2022-07-18 at 1 13 01 PM](https://user-images.githubusercontent.com/5998100/179599040-dbcc8d73-2013-4d6a-b5e3-7413eece8e77.png)


