### PR TITLE
Increase default toast duration to 6 seconds

### DIFF
--- a/libs/ui/src/theme/HausThemeContext.tsx
+++ b/libs/ui/src/theme/HausThemeContext.tsx
@@ -32,7 +32,7 @@ export const HausThemeContext = createContext<HausUI>({
   setToast: (): void => undefined,
 });
 
-const DEFAULT_TOAST_DURATION = 2000;
+const DEFAULT_TOAST_DURATION = 6000;
 
 export const HausThemeProvider = ({
   children,


### PR DESCRIPTION
## GitHub Issue

[Add a link to the GitHub issue.](https://github.com/HausDAO/daohaus-monorepo/issues/604)

## Changes

Increase toast duration to 6 seconds

## Packages Added

n/a

## Checks

Before making your PR, please check the following:

- [x] Critical lint errors are resolved
- [x] App runs locally
- [ ] App builds locally (run the build command for *any impacted package* and check for any errors before the PR)
