### PR TITLE
add button to fieldWrapper

### DIFF
--- a/libs/ui/src/components/molecules/FieldWrapper/FieldWrapper.stories.tsx
+++ b/libs/ui/src/components/molecules/FieldWrapper/FieldWrapper.stories.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import { FieldWrapper } from './FieldWrapper';
 import { field } from '../../../theme';
 import { border } from '../../../theme/global/border';
+import { Button } from '../../atoms/Button';
 import { ParXs } from '../../atoms/Typography';
 
 export default {
@@ -31,6 +32,18 @@ FieldWrapperComponent.args = {
     message: 'This is Success helper text',
   },
   info: 'Cooltip text',
+};
+
+export const FieldWrapperWithButtonComponent = Template.bind({});
+FieldWrapperWithButtonComponent.args = {
+  children: <DummyField>Sample dummy component</DummyField>,
+  label: 'Label',
+  success: {
+    type: 'success',
+    message: 'This is Success helper text',
+  },
+  info: 'Cooltip text',
+  rightAddon: <Button tertiary sm>Button Label</Button>,
 };
 
 export const HelperTextPriority = Template.bind({});

--- a/libs/ui/src/components/molecules/FieldWrapper/FieldWrapper.styles.ts
+++ b/libs/ui/src/components/molecules/FieldWrapper/FieldWrapper.styles.ts
@@ -30,6 +30,25 @@ export const LabelContainer = styled.label`
   }
 `;
 
+export const BottomContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+  width: 100%;
+  max-width: ${field.size.md};
+  &.long {
+    max-width: ${field.size.lg};
+  }
+  &.full {
+    max-width: ${field.size.full};
+  }
+`;
+
+export const RightAddonContainer = styled.div`
+  padding-left: 1em;
+`;
+
 export const RequiredAsterisk = styled.span`
   margin-right: 8px;
   font-weight: ${font.weight.bold};

--- a/libs/ui/src/components/molecules/FieldWrapper/FieldWrapper.tsx
+++ b/libs/ui/src/components/molecules/FieldWrapper/FieldWrapper.tsx
@@ -12,9 +12,11 @@ import {
   WarningText,
 } from '../../atoms/HelperTexts';
 import {
+  BottomContainer,
   FieldWrapperBase,
   LabelContainer,
   RequiredAsterisk,
+  RightAddonContainer,
 } from './FieldWrapper.styles';
 import { Buildable } from '../../../types/formAndField';
 import {
@@ -46,6 +48,7 @@ export const FieldWrapper = ({
   address,
   id,
   rules,
+  rightAddon,
 }: Buildable<{ children: ReactNode }>) => {
   const classes = classNames({ long: long || address, full });
   const { getFieldState } = useFormContext();
@@ -66,12 +69,17 @@ export const FieldWrapper = ({
         {info && <Tooltip content={info} />}
       </LabelContainer>
       <div className="field-slot">{children}</div>
-      <HelperTextFactory
-        error={error || fieldError}
-        success={success}
-        warning={warning}
-        helperText={helperText}
-      />
+      <BottomContainer className={classes}>
+        <HelperTextFactory
+          error={error || fieldError}
+          success={success}
+          warning={warning}
+          helperText={helperText}
+        />
+        {rightAddon && (
+          <RightAddonContainer>{rightAddon}</RightAddonContainer>
+        )}
+      </BottomContainer>
     </FieldWrapperBase>
   );
 };

--- a/libs/ui/src/types/formAndField.ts
+++ b/libs/ui/src/types/formAndField.ts
@@ -1,4 +1,4 @@
-import { ChangeEventHandler } from 'react';
+import React, { ChangeEventHandler } from 'react';
 import { RegisterOptions } from 'react-hook-form';
 
 export type ErrorMessage = {
@@ -35,11 +35,15 @@ export type PrimitiveSizable = {
   full?: boolean;
 };
 
+export type PrimitiveAddons = {
+  rightAddon?: React.ReactNode
+}
+
 export type HasRules = {
   rules?: RegisterOptions;
 };
 
-type FieldWrapper = PrimitiveWrapper & PrimitiveElement & PrimitiveSizable;
+type FieldWrapper = PrimitiveWrapper & PrimitiveElement & PrimitiveSizable & PrimitiveAddons;
 
 export type Buildable<T> = T & FieldWrapper & HasRules;
 


### PR DESCRIPTION
## GitHub Issue

#568 

## Changes

Add a rightAddon slot so components like a modifier button can be added to FieldWrapper

## Packages Added

None

## Checks

Before making your PR, please check the following:

- [X] Critical lint errors are resolved
- [X] App runs locally
- [X] App builds locally (run the build command for *any impacted package* and check for any errors before the PR)
