### PR TITLE
Center loading animation in Summon flow

### DIFF
--- a/apps/summon-app/src/layouts/FormLayouts.tsx
+++ b/apps/summon-app/src/layouts/FormLayouts.tsx
@@ -34,8 +34,8 @@ export const CenterLayout = styled.main`
 
 export const BlockImageContainer = styled.div`
   display: flex;
-  justify-content: flex-end;
-  align-items: flex-end;
+  justify-content: center;
+  align-items: center;
   height: 26rem;
   width: 100%;
   margin-bottom: 2.4rem;


### PR DESCRIPTION
## GitHub Issue

https://github.com/HausDAO/daohaus-monorepo/issues/576

## Changes

In `<BlockImageContainer>` component

Changed:

- justify-content: center;
- align-items: center;

<img width="725" alt="image" src="https://user-images.githubusercontent.com/522182/184391522-77ebf861-3bcc-4cb3-aa0a-80d69bb138b1.png">

## Packages Added

N/A

## Checks

Before making your PR, please check the following:

- [x] Critical lint errors are resolved
- [x] App runs locally
- [x] App builds locally (run the build command for *any impacted package* and check for any errors before the PR)
