### PR TITLE
Update link text and add external link type

### DIFF
--- a/apps/hub-app/src/components/Profile.tsx
+++ b/apps/hub-app/src/components/Profile.tsx
@@ -113,7 +113,7 @@ export const HeaderProfile = () => {
           {
             type: 'clickable',
             content: (
-              <StyledExternalLink href={LENS_PROFILE_URL}>
+              <StyledExternalLink href={LENS_PROFILE_URL} linkType="external">
                 <StyledParMd>Edit Lens Profile</StyledParMd>
               </StyledExternalLink>
             ),
@@ -122,7 +122,7 @@ export const HeaderProfile = () => {
             type: 'clickable',
             content: (
               <StyledLink to={`/profile/${address}`}>
-                <StyledParMd>View Public</StyledParMd>
+                <StyledParMd>View Public Profile</StyledParMd>
               </StyledLink>
             ),
           },


### PR DESCRIPTION
## GitHub Issue

https://github.com/HausDAO/daohaus-monorepo/issues/550

## Changes

Changed:

`<StyledParMd>View Public</StyledParMd>`

To:

`<StyledParMd>View Public Profile</StyledParMd>`

Added:

`linkType="external"`

to Lens Profile link

<img width="442" alt="image" src="https://user-images.githubusercontent.com/522182/184397769-c54f32dc-cc83-4210-88a1-a0fc0da687bf.png">

## Packages Added

N/A

## Checks

Before making your PR, please check the following:

- [x] Critical lint errors are resolved
- [x] App runs locally
- [x] App builds locally (run the build command for *any impacted package* and check for any errors before the PR)
