### PR TITLE
Feature/97 create global banner notice component

### DIFF
--- a/libs/ui/src/components/atoms/Link/Link.tsx
+++ b/libs/ui/src/components/atoms/Link/Link.tsx
@@ -10,7 +10,7 @@ export interface LinkProps extends React.ComponentPropsWithRef<'a'> {
   Icon?: IconType;
   selected?: boolean;
   disabled?: boolean;
-  linkType?: 'internal' | 'external';
+  linkType?: 'internal' | 'external' | 'no-icon-external';
   hideIcon?: boolean;
 }
 
@@ -30,7 +30,7 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
     ref
   ) => {
     const classes = classNames({ selected, disabled });
-    if (linkType === 'external') {
+    if (linkType === 'external' || linkType === 'no-icon-external') {
       return (
         <ExternalLink
           href={href}
@@ -39,7 +39,13 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
           ref={ref}
         >
           {children}
-          {Icon ? <Icon /> : <RiExternalLinkLine />}
+          {linkType === 'external' ? (
+            Icon ? (
+              <Icon />
+            ) : (
+              <RiExternalLinkLine />
+            )
+          ) : null}
         </ExternalLink>
       );
     }

--- a/libs/ui/src/components/molecules/Banner/Banner.stories.tsx
+++ b/libs/ui/src/components/molecules/Banner/Banner.stories.tsx
@@ -7,11 +7,13 @@ export default {
 } as ComponentMeta<typeof Banner>;
 
 const Template: ComponentStory<typeof Banner> = (args) => {
-  return <Banner>{args.children}</Banner>;
+  return <Banner {...args} />;
 };
 
 export const BaseBanner = Template.bind({});
+BaseBanner.args = {};
 
-BaseBanner.args = {
-  children: <p>Content in a Card</p>,
+export const BannerWithCustomText = Template.bind({});
+BannerWithCustomText.args = {
+  bannerText: 'Hello from Rowdy',
 };

--- a/libs/ui/src/components/molecules/Banner/Banner.stories.tsx
+++ b/libs/ui/src/components/molecules/Banner/Banner.stories.tsx
@@ -1,0 +1,17 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import { Banner } from './Banner';
+
+export default {
+  title: 'Molecules/Banner',
+  component: Banner,
+} as ComponentMeta<typeof Banner>;
+
+const Template: ComponentStory<typeof Banner> = (args) => {
+  return <Banner>{args.children}</Banner>;
+};
+
+export const BaseBanner = Template.bind({});
+
+BaseBanner.args = {
+  children: <p>Content in a Card</p>,
+};

--- a/libs/ui/src/components/molecules/Banner/Banner.styles.ts
+++ b/libs/ui/src/components/molecules/Banner/Banner.styles.ts
@@ -12,7 +12,7 @@ export const StyledBanner = styled.div`
   height: auto;
   justify-content: space-between;
   min-height: 8rem;
-  padding: 2rem;
+  padding: 2rem 4rem;
   width: 100%;
 
   .banner--text-container {

--- a/libs/ui/src/components/molecules/Banner/Banner.styles.ts
+++ b/libs/ui/src/components/molecules/Banner/Banner.styles.ts
@@ -8,10 +8,12 @@ export const StyledBanner = styled.div`
   background-color: ${({ theme }: { theme: Theme }) => theme.info};
   border: 1px solid ${({ theme }: { theme: Theme }) => theme.info};
   color: ${({ theme }) => theme.fontColor};
-  height: 8rem;
+  flex-wrap: wrap;
+  height: auto;
+  justify-content: space-between;
+  min-height: 8rem;
   padding: 2rem;
   width: 100%;
-  justify-content: space-between;
 
   .banner--text-container {
     align-items: center;

--- a/libs/ui/src/components/molecules/Banner/Banner.styles.ts
+++ b/libs/ui/src/components/molecules/Banner/Banner.styles.ts
@@ -1,0 +1,39 @@
+import styled from 'styled-components';
+
+import { Theme } from '../../../types/theming';
+
+export const StyledBanner = styled.div`
+  align-items: center;
+  display: flex;
+  background-color: ${({ theme }: { theme: Theme }) => theme.info};
+  border: 1px solid ${({ theme }: { theme: Theme }) => theme.info};
+  color: ${({ theme }) => theme.fontColor};
+  height: 8rem;
+  padding: 2rem;
+  width: 100%;
+  justify-content: space-between;
+
+  .banner--text-container {
+    align-items: center;
+    display: flex;
+
+    svg {
+      font-size: 2.8rem;
+      margin-right: 1.4rem;
+    }
+  }
+
+  .banner--link-container {
+    align-items: center;
+    display: flex;
+
+    svg {
+      font-size: 2.4rem;
+      margin-right: 1rem;
+    }
+  }
+
+  .banner--link-item {
+    margin: 0 6rem;
+  }
+`;

--- a/libs/ui/src/components/molecules/Banner/Banner.tsx
+++ b/libs/ui/src/components/molecules/Banner/Banner.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { RiDiscordFill, RiToolsLine } from 'react-icons/ri';
+import { Link, ParMd } from '../../atoms';
+
+import { StyledBanner } from './Banner.styles';
+
+export type BannerProps = {
+  bannerText: string;
+  className?: string;
+};
+
+export const Banner = ({ className, bannerText }: BannerProps) => {
+  return (
+    <StyledBanner className={className}>
+      <div className="banner--text-container">
+        <RiToolsLine />
+        <ParMd>
+          {bannerText ||
+            'DAO Haus V3 is currently in Beta, not all feature will be inplace and bugs may appear.'}
+        </ParMd>
+      </div>
+      <div className="banner--link-container">
+        <Link
+          href="https://github.com/HausDAO/daohaus-monorepo/issues/new/choose"
+          linkType="no-icon-external"
+          className="banner--link-item"
+        >
+          Give Feedback
+        </Link>
+        <Link linkType="no-icon-external" href="https://discord.gg/daohaus">
+          <RiDiscordFill />
+          Support
+        </Link>
+      </div>
+    </StyledBanner>
+  );
+};

--- a/libs/ui/src/components/molecules/Banner/Banner.tsx
+++ b/libs/ui/src/components/molecules/Banner/Banner.tsx
@@ -5,19 +5,19 @@ import { Link, ParMd } from '../../atoms';
 import { StyledBanner } from './Banner.styles';
 
 export type BannerProps = {
-  bannerText: string;
+  bannerText?: string;
   className?: string;
 };
 
-export const Banner = ({ className, bannerText }: BannerProps) => {
+export const Banner = ({
+  className,
+  bannerText = 'DAO Haus V3 is currently in Beta, not all feature will be inplace and bugs may appear.',
+}: BannerProps) => {
   return (
     <StyledBanner className={className}>
       <div className="banner--text-container">
         <RiToolsLine />
-        <ParMd>
-          {bannerText ||
-            'DAO Haus V3 is currently in Beta, not all feature will be inplace and bugs may appear.'}
-        </ParMd>
+        <ParMd>{bannerText}</ParMd>
       </div>
       <div className="banner--link-container">
         <Link

--- a/libs/ui/src/components/molecules/Banner/index.ts
+++ b/libs/ui/src/components/molecules/Banner/index.ts
@@ -1,0 +1,1 @@
+export * from './Banner';


### PR DESCRIPTION
## GitHub Issue

Link to the [GitHub issue](https://github.com/HausDAO/daohaus-monorepo/issues/97).

## Changes

Built out Banner Component to for displaying that the app is currently in Beta

![Screen Shot 2022-08-31 at 8 54 20 AM](https://user-images.githubusercontent.com/22626267/187725105-efb5ce6f-08f9-4cdf-a096-c7f854fc4f2f.png)

## Packages Added

NA

## Checks

Before making your PR, please check the following:

- [x] Critical lint errors are resolved
- [x] App runs locally
- [x] App builds locally (run the build command for *any impacted package* and check for any errors before the PR)
