### PR TITLE
removing dao-data from ui

### DIFF
--- a/apps/core-app/src/components/DaoCard.tsx
+++ b/apps/core-app/src/components/DaoCard.tsx
@@ -5,7 +5,7 @@ import {
   getNetworkName,
   readableNumbers,
 } from '@daohaus/common-utilities';
-import { ITransformedMembership } from '@daohaus/dao-data';
+import { ITransformedMembership } from '@daohaus/common-utilities';
 import {
   Badge,
   Bold,

--- a/apps/core-app/src/components/DaoList.tsx
+++ b/apps/core-app/src/components/DaoList.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-import { ITransformedMembership } from '@daohaus/dao-data';
+import { ITransformedMembership } from '@daohaus/common-utilities';
 import { breakpoints } from '@daohaus/ui';
 
 import { DaoCard } from './DaoCard';

--- a/apps/core-app/src/components/DaoTable.tsx
+++ b/apps/core-app/src/components/DaoTable.tsx
@@ -3,7 +3,7 @@ import { useTable, Column, UseTableRowProps } from 'react-table';
 import styled from 'styled-components';
 import { indigoDark } from '@radix-ui/colors';
 
-import { ITransformedMembership } from '@daohaus/dao-data';
+import { ITransformedMembership } from '@daohaus/common-utilities';
 import { ProfileAvatar, Tag } from '@daohaus/ui';
 import {
   charLimit,

--- a/apps/core-app/src/components/HomeDashboard.tsx
+++ b/apps/core-app/src/components/HomeDashboard.tsx
@@ -4,9 +4,10 @@ import styled from 'styled-components';
 import {
   handleErrorMessage,
   isValidNetwork,
+  ITransformedMembership,
   ValidNetwork,
 } from '@daohaus/common-utilities';
-import { Haus, ITransformedMembership } from '@daohaus/dao-data';
+import { Haus } from '@daohaus/dao-data';
 import {
   H2,
   Spinner,

--- a/apps/core-app/src/components/Profile.tsx
+++ b/apps/core-app/src/components/Profile.tsx
@@ -12,7 +12,7 @@ import {
   DataIndicator,
   widthQuery,
 } from '@daohaus/ui';
-import { AccountProfile } from '@daohaus/dao-data';
+import { AccountProfile } from '@daohaus/common-utilities';
 import {
   formatLongDateFromSeconds,
   formatValueTo,

--- a/apps/core-app/src/components/customFields/RagequitTokenList.tsx
+++ b/apps/core-app/src/components/customFields/RagequitTokenList.tsx
@@ -19,7 +19,7 @@ import {
 import { useConnectedMembership, useDao } from '@daohaus/dao-context';
 import { CheckboxProps, CheckedState } from '@radix-ui/react-checkbox';
 import styled from 'styled-components';
-import { TokenBalance } from '@daohaus/dao-data';
+import { TokenBalance } from '@daohaus/common-utilities';
 import { useParams } from 'react-router-dom';
 import { sortTokensForRageQuit } from '../../utils/general';
 

--- a/apps/core-app/src/pages/Member.tsx
+++ b/apps/core-app/src/pages/Member.tsx
@@ -24,8 +24,9 @@ import {
   memberUsdValueShare,
   charLimit,
   NETWORK_TOKEN_ETH_ADDRESS,
+  AccountProfile,
 } from '@daohaus/common-utilities';
-import { AccountProfile, FindMemberQuery, Haus } from '@daohaus/dao-data';
+import { FindMemberQuery, Haus } from '@daohaus/dao-data';
 
 import { useDao } from '@daohaus/dao-context';
 import { Profile } from '../components/Profile';

--- a/apps/core-app/src/utils/tokenData.ts
+++ b/apps/core-app/src/utils/tokenData.ts
@@ -1,5 +1,9 @@
-import { NETWORK_DATA, ValidNetwork } from '@daohaus/common-utilities';
-import { DaoWithTokenData, TokenBalance } from '@daohaus/dao-data';
+import {
+  NETWORK_DATA,
+  TokenBalance,
+  ValidNetwork,
+} from '@daohaus/common-utilities';
+import { DaoWithTokenData } from '@daohaus/dao-data';
 
 const isNetworkToken = (tokenData: TokenBalance) => {
   return !tokenData.token;

--- a/apps/hub-app/src/components/DaoCard.tsx
+++ b/apps/hub-app/src/components/DaoCard.tsx
@@ -15,7 +15,7 @@ import {
   ProfileAvatar,
 } from '@daohaus/ui';
 import { AlertCircle } from './AlertCircle';
-import { ITransformedMembership } from '@daohaus/dao-data';
+import { ITransformedMembership } from '@daohaus/common-utilities';
 
 const StyledDaoCard = styled.div`
   background-color: ${(props) => props.theme.card.bg};

--- a/apps/hub-app/src/components/DaoCards.tsx
+++ b/apps/hub-app/src/components/DaoCards.tsx
@@ -1,4 +1,4 @@
-import { ITransformedMembership } from '@daohaus/dao-data';
+import { ITransformedMembership } from '@daohaus/common-utilities';
 import { breakpoints } from '@daohaus/ui';
 import styled from 'styled-components';
 import { DaoCard } from './DaoCard';

--- a/apps/hub-app/src/components/DaoTable.tsx
+++ b/apps/hub-app/src/components/DaoTable.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ITransformedMembership } from '@daohaus/dao-data';
+import { ITransformedMembership } from '@daohaus/common-utilities';
 import { useTable, Column, UseTableRowProps } from 'react-table';
 import styled from 'styled-components';
 import { indigoDark } from '@radix-ui/colors';

--- a/apps/hub-app/src/components/HomeDashboard.tsx
+++ b/apps/hub-app/src/components/HomeDashboard.tsx
@@ -1,5 +1,5 @@
 import { MouseEvent, useState, ChangeEvent } from 'react';
-import { ITransformedMembership } from '@daohaus/dao-data';
+import { ITransformedMembership } from '@daohaus/common-utilities';
 import { ParMd, Spinner, useBreakpoint, widthQuery } from '@daohaus/ui';
 import styled from 'styled-components';
 

--- a/apps/hub-app/src/hooks/useDaoData.tsx
+++ b/apps/hub-app/src/hooks/useDaoData.tsx
@@ -1,7 +1,11 @@
 import { useEffect, useState } from 'react';
 import { useHausConnect } from '@daohaus/daohaus-connect-feature';
-import { Haus, ITransformedMembership } from '@daohaus/dao-data';
-import { NETWORK_DATA, ValidNetwork } from '@daohaus/common-utilities';
+import { Haus } from '@daohaus/dao-data';
+import {
+  ITransformedMembership,
+  NETWORK_DATA,
+  ValidNetwork,
+} from '@daohaus/common-utilities';
 
 const temporaryInitHaus = () => {
   return Haus.create();

--- a/apps/hub-app/src/pages/HomePage.tsx
+++ b/apps/hub-app/src/pages/HomePage.tsx
@@ -2,6 +2,7 @@ import { MouseEvent, ChangeEvent, useEffect, useState } from 'react';
 import { useHausConnect } from '@daohaus/daohaus-connect-feature';
 import {
   isValidNetwork,
+  ITransformedMembership,
   NETWORK_DATA,
   ValidNetwork,
 } from '@daohaus/common-utilities';
@@ -21,7 +22,7 @@ import { HomeNotConnected } from './HomeNotConnected';
 import { getDelegateFilter } from '../utils/queryHelpers';
 import { DEFAULT_SORT_KEY, SORT_FIELDS } from '../utils/constants';
 import useDebounce from '../utils/debounceHook';
-import { Haus, ITransformedMembership } from '@daohaus/dao-data';
+import { Haus } from '@daohaus/dao-data';
 
 const HomePage = () => {
   const { isConnected, address } = useHausConnect();

--- a/apps/hub-app/src/pages/PublicProfilePage.tsx
+++ b/apps/hub-app/src/pages/PublicProfilePage.tsx
@@ -13,7 +13,7 @@ import {
   useToast,
   Tag,
 } from '@daohaus/ui';
-import { ITransformedMembership } from '@daohaus/dao-data';
+import { ITransformedMembership } from '@daohaus/common-utilities';
 import { BsShareFill, BsArrowLeft } from 'react-icons/bs';
 import useDaoData from '../hooks/useDaoData';
 import { Layout } from '../components/Layout';

--- a/libs/common-utilities/src/types/index.ts
+++ b/libs/common-utilities/src/types/index.ts
@@ -3,3 +3,4 @@ export * from './react';
 export * from './contract';
 export * from './general';
 export * from './legoTypes';
+export * from './query';

--- a/libs/common-utilities/src/types/query.ts
+++ b/libs/common-utilities/src/types/query.ts
@@ -19,12 +19,14 @@ export interface ITransformedMembership {
 export interface ITransformedMembershipsQuery {
   daos: ITransformedMembership[];
 }
+
 export type TokenInfo = {
   decimals: number;
   symbol: string;
   name: string;
   logoUri: string | null;
 };
+
 export type TokenBalance = {
   token: TokenInfo | null;
   tokenAddress: string | null;

--- a/libs/common-utilities/src/types/query.ts
+++ b/libs/common-utilities/src/types/query.ts
@@ -1,0 +1,54 @@
+import { Keychain } from './keychains';
+
+export interface ITransformedMembership {
+  dao: string;
+  name?: string;
+  safeAddress: string;
+  activeProposalCount: number;
+  activeMemberCount: string;
+  votingPower: number;
+  networkId?: keyof Keychain;
+  delegatingTo?: string;
+  isDelegate: boolean;
+  memberAddress: string;
+  fiatTotal?: number;
+  totalProposalCount: string;
+  contractType: string;
+  tokenBalances?: TokenBalance[];
+}
+export interface ITransformedMembershipsQuery {
+  daos: ITransformedMembership[];
+}
+export type TokenInfo = {
+  decimals: number;
+  symbol: string;
+  name: string;
+  logoUri: string | null;
+};
+export type TokenBalance = {
+  token: TokenInfo | null;
+  tokenAddress: string | null;
+  balance: string;
+  ethValue: string;
+  timestamp: string;
+  fiatBalance: string;
+  fiatConversion: string;
+  fiatCode: string;
+};
+export type DaoTokenBalances = {
+  safeAddress: string;
+  fiatTotal: number;
+  tokenBalances: TokenBalance[];
+};
+
+export type AccountProfile = {
+  address: string;
+  ens?: string;
+  image?: string;
+  name?: string;
+  description?: string;
+  emoji?: string;
+  lensHandle?: string;
+  lensId?: string;
+  daos?: ITransformedMembershipsQuery['daos'];
+};

--- a/libs/dao-data/src/Profile.ts
+++ b/libs/dao-data/src/Profile.ts
@@ -1,14 +1,16 @@
-import { Keychain } from '@daohaus/common-utilities';
 import {
   AccountProfile,
-  ICrossNetworkMemberListArguments,
   DaoTokenBalances,
+  ITransformedMembershipsQuery,
+  Keychain,
+} from '@daohaus/common-utilities';
+import {
+  ICrossNetworkMemberListArguments,
   ListMembershipsDocument,
   ListMembershipsQuery,
   ListMembershipsQueryVariables,
   Member_OrderBy,
   IFindQueryResult,
-  ITransformedMembershipsQuery,
   Dao_OrderBy,
   Member_Filter,
   LensProfile,

--- a/libs/dao-data/src/Query.ts
+++ b/libs/dao-data/src/Query.ts
@@ -1,10 +1,14 @@
-import { ENDPOINTS, Keychain, KeychainList } from '@daohaus/common-utilities';
+import {
+  DaoTokenBalances,
+  ENDPOINTS,
+  Keychain,
+  KeychainList,
+  TokenBalance,
+} from '@daohaus/common-utilities';
 
 import {
   IListQueryArguments,
   IFindQueryResult,
-  DaoTokenBalances,
-  TokenBalance,
   ITransformedProposalQuery,
   ITransformedProposalListQuery,
   DaoWithTokenDataQuery,

--- a/libs/dao-data/src/types/profile.types.ts
+++ b/libs/dao-data/src/types/profile.types.ts
@@ -1,16 +1,3 @@
-import { ITransformedMembershipsQuery } from './query.types';
 import { ListProfileQuery } from '../subgraph/queries-lens/profiles.generated';
 
 export type LensProfile = ListProfileQuery['profiles']['items'][number];
-
-export type AccountProfile = {
-  address: string;
-  ens?: string;
-  image?: string;
-  name?: string;
-  description?: string;
-  emoji?: string;
-  lensHandle?: string;
-  lensId?: string;
-  daos?: ITransformedMembershipsQuery['daos'];
-};

--- a/libs/dao-data/src/types/query.types.ts
+++ b/libs/dao-data/src/types/query.types.ts
@@ -1,4 +1,4 @@
-import { Keychain } from '@daohaus/common-utilities';
+import { Keychain, TokenBalance } from '@daohaus/common-utilities';
 import { HausError } from '../HausError';
 import { ListDaosQuery } from '../subgraph/queries/daos.generated';
 import { ListProposalsQuery } from '../subgraph/queries/proposals.generated';
@@ -80,47 +80,6 @@ export interface ITransformedProposalListQuery {
   proposals: ITransformedProposal[];
 }
 
-export interface ITransformedMembership {
-  dao: string;
-  name?: string;
-  safeAddress: string;
-  activeProposalCount: number;
-  activeMemberCount: string;
-  votingPower: number;
-  networkId?: keyof Keychain;
-  delegatingTo?: string;
-  isDelegate: boolean;
-  memberAddress: string;
-  fiatTotal?: number;
-  totalProposalCount: string;
-  contractType: string;
-  tokenBalances?: TokenBalance[];
-}
-export interface ITransformedMembershipsQuery {
-  daos: ITransformedMembership[];
-}
-export type TokenInfo = {
-  decimals: number;
-  symbol: string;
-  name: string;
-  logoUri: string | null;
-};
-export type TokenBalance = {
-  token: TokenInfo | null;
-  tokenAddress: string | null;
-  balance: string;
-  ethValue: string;
-  timestamp: string;
-  fiatBalance: string;
-  fiatConversion: string;
-  fiatCode: string;
-};
-export type DaoTokenBalances = {
-  safeAddress: string;
-  fiatTotal: number;
-  tokenBalances: TokenBalance[];
-};
-
 export type DaoProfile = {
   description?: string;
   longDescription?: string;
@@ -141,6 +100,7 @@ export type DaoWithTokenData = {
   fiatTotal: number;
   tokenBalances: TokenBalance[];
 } & ITransformedDao;
+
 export type DaoWithTokenDataQuery = {
   dao: DaoWithTokenData;
 };

--- a/libs/dao-data/src/types/query.types.ts
+++ b/libs/dao-data/src/types/query.types.ts
@@ -69,6 +69,10 @@ export type QueryProposal = ListProposalsQuery['proposals'][number];
 export interface ITransformedProposal extends QueryProposal {
   status?: string;
 }
+
+// copied files start here  in @daohaus/dao-data
+// moving this to common-utilities allows the UI to remove dao-data
+// from its dependencies
 export interface ITransformedProposalQuery {
   proposal: ITransformedProposal | undefined;
 }

--- a/libs/dao-data/src/utils/transformers.ts
+++ b/libs/dao-data/src/utils/transformers.ts
@@ -1,11 +1,13 @@
-import { votingPowerPercentage } from '@daohaus/common-utilities';
+import {
+  AccountProfile,
+  DaoTokenBalances,
+  ITransformedMembership,
+  TokenBalance,
+  votingPowerPercentage,
+} from '@daohaus/common-utilities';
 import {
   ITransformedProposal,
-  ITransformedMembership,
   IFindQueryResult,
-  AccountProfile,
-  TokenBalance,
-  DaoTokenBalances,
   QueryProposal,
   ListMembershipsQuery,
   DaoProfile,

--- a/libs/daohaus-connect-feature/src/utils/types.ts
+++ b/libs/daohaus-connect-feature/src/utils/types.ts
@@ -1,8 +1,7 @@
 import { providers } from 'ethers';
 import { ICoreOptions } from 'web3modal';
 
-import { AccountProfile } from '@daohaus/dao-data';
-import { Keychain } from '@daohaus/common-utilities';
+import { AccountProfile, Keychain } from '@daohaus/common-utilities';
 
 export type ModalEvents = (
   eventName: 'error' | 'accountsChanged' | 'chainChanged',

--- a/libs/ui/src/components/organisms/MemberCard/MemberCard.tsx
+++ b/libs/ui/src/components/organisms/MemberCard/MemberCard.tsx
@@ -6,7 +6,7 @@ import {
   truncateAddress,
   ValidNetwork,
 } from '@daohaus/common-utilities';
-import { AccountProfile } from '@daohaus/dao-data';
+import { AccountProfile } from '@daohaus/common-utilities';
 
 import { ParMd } from '../../atoms';
 


### PR DESCRIPTION
## GitHub Issue

https://github.com/HausDAO/daohaus-monorepo/issues/881

## Changes

one thing we can think about doing is creating a `types` folder under libs and nest different types in that folder - we can export that entire folder as one package AND split those nested types up into their own packages, that way people can choose which package to include, similar to how `ethers` does this.

https://github.com/ethereumjs/ethereumjs-monorepo#packages

you can see their dependency tree here

https://github.com/ethereumjs/ethereumjs-monorepo#package-dependency-relationship

## Packages Added

Brief list of any packages added, and if folks need to rerun `yarn install` to run locally

## Checks

Before making your PR, please check the following:

- [ ] Critical lint errors are resolved
- [ ] App runs locally
- [ ] App builds locally (run the build command for *any impacted package* and check for any errors before the PR)
