### PR TITLE
Add a estimateGas fallback when gnosis API returns 404

### DIFF
--- a/apps/core-app/src/components/proposalCards/ReadyForProcessing.tsx
+++ b/apps/core-app/src/components/proposalCards/ReadyForProcessing.tsx
@@ -88,9 +88,8 @@ export const ReadyForProcessing = ({
 
   const processProposal = async () => {
     const { proposalId, proposalData, actionGasEstimate } = proposal;
-    const processingGasLimit = (
-      Number(actionGasEstimate) + PROCESS_PROPOSAL_GAS_LIMIT_ADDITION
-    ).toFixed();
+    const processingGasLimit = Number(actionGasEstimate) > 0 && 
+      Number(actionGasEstimate) + PROCESS_PROPOSAL_GAS_LIMIT_ADDITION;
 
     if (!proposalId) return;
     setIsLoading(true);
@@ -98,7 +97,10 @@ export const ReadyForProcessing = ({
       tx: {
         ...ACTION_TX.PROCESS,
         staticArgs: [proposalId, proposalData],
-        overrides: { gasLimit: processingGasLimit },
+        // Usually a proposal actionGasEstimate === 0 when the safe vault takes longer to 
+        // be indexed by the Gnosis API (a DAO was recently summonned)
+        // In this case, do not override gasLimit
+        overrides: processingGasLimit ? { gasLimit: processingGasLimit.toFixed() } : {},
       } as TXLego,
       lifeCycleFns: {
         onTxError: (error) => {

--- a/libs/contract-utilities/src/lib/estimate-util.ts
+++ b/libs/contract-utilities/src/lib/estimate-util.ts
@@ -37,12 +37,15 @@ export const estimateGas = async ({
       }),
     });
 
-    const estimate = await response.json();
+    const estimate = response.ok ? await response.json() : {};
 
-    if (estimate.safeTxGas) {
+    if (estimate?.safeTxGas) {
       return Math.round(Number(estimate.safeTxGas) * Number(1.6));
     } else {
-      throw new Error(`Failed to estimate gas: `);
+      // This happens when the safe vault takes longer to be indexed by the Gnosis API
+      // and it returns a 404 HTTP error
+      console.error(`Failed to estimate gas:`, response.statusText);
+      return 0;
     }
   } catch (error) {
     throw new Error(`Failed to estimate gas: ${error}`);

--- a/libs/tx-builder-feature/src/utils/multicall.ts
+++ b/libs/tx-builder-feature/src/utils/multicall.ts
@@ -65,8 +65,9 @@ export const estimateGas = async ({
         operation: 1,
       }),
     });
-
-    return response.json();
+    if (response.ok) {
+      return response.json();
+    }
   } catch (error) {
     throw new Error(`Failed to estimate gas: ${error}`);
   }
@@ -207,11 +208,14 @@ export const handleGasEstimate = async ({
   });
 
   console.log('estimate', estimate);
-  if (estimate.safeTxGas) {
+  if (estimate?.safeTxGas) {
     const buffer = arg.bufferPercentage ? `1.${arg.bufferPercentage}` : 1.6;
     return Math.round(Number(estimate.safeTxGas) * Number(buffer));
   } else {
-    throw new Error(`Failed to estimate gas: `);
+    // This happens when the safe vault takes longer to be indexed by the Gnosis API
+    // and it returns a 404 HTTP error
+    console.error(`Failed to estimate gas`);
+    return 0;
   }
 };
 export const encodeMultiAction = (rawMulti: MetaTransaction[]) => {


### PR DESCRIPTION
## GitHub Issue

Closes #898 

## Changes

Sometimes it takes longer for the Gnosis API to index a Safe deployed during a Baal summoning event. When this happens, it's not possible to submit DAO proposals as the app fails to estimate `baalGas`. This issue is happening on Goerli but It may also appear in production, so as a fallback and until the Safe is available through the API, `baalGas` is set to zero when calling `submitProposal`, while `gasLimit` is not overridden when `processProposal` is executed

## Packages Added

None

## Checks

Before making your PR, please check the following:

- [X] Critical lint errors are resolved
- [X] App runs locally
- [X] App builds locally (run the build command for *any impacted package* and check for any errors before the PR)
