### PR TITLE
build typecheckers, messages display, don't commit anything

### DIFF
--- a/apps/core-app/src/components/proposalCards/ProposalActions.tsx
+++ b/apps/core-app/src/components/proposalCards/ProposalActions.tsx
@@ -6,7 +6,6 @@ import { ActionFailed } from './ActionFailed';
 import { ActionTemplate } from './ActionPrimitives';
 import { Cancelled } from './Cancelled';
 import { Expired } from './Expired';
-import { Failed } from './Failed';
 import { GracePeriod } from './GracePeriod';
 import { Passed } from './Passed';
 import { ReadyForProcessing } from './ReadyForProcessing';
@@ -74,7 +73,10 @@ export const ProposalActions = ({
   if (proposal.status === PROPOSAL_STATUS.failed) {
     return (
       <ActionBox>
-        <Failed proposal={proposal} />
+        {/* <Failed proposal={proposal} /> */}
+        <VotingPeriod proposal={proposal} />
+
+        {/* <ReadyForProcessing proposal={proposal} /> */}
       </ActionBox>
     );
   }

--- a/apps/core-app/src/components/proposalCards/ProposalActions.tsx
+++ b/apps/core-app/src/components/proposalCards/ProposalActions.tsx
@@ -6,6 +6,7 @@ import { ActionFailed } from './ActionFailed';
 import { ActionTemplate } from './ActionPrimitives';
 import { Cancelled } from './Cancelled';
 import { Expired } from './Expired';
+import { Failed } from './Failed';
 import { GracePeriod } from './GracePeriod';
 import { Passed } from './Passed';
 import { ReadyForProcessing } from './ReadyForProcessing';
@@ -73,10 +74,7 @@ export const ProposalActions = ({
   if (proposal.status === PROPOSAL_STATUS.failed) {
     return (
       <ActionBox>
-        {/* <Failed proposal={proposal} /> */}
-        <VotingPeriod proposal={proposal} />
-
-        {/* <ReadyForProcessing proposal={proposal} /> */}
+        <Failed proposal={proposal} />
       </ActionBox>
     );
   }

--- a/apps/core-app/src/components/proposalCards/ReadyForProcessing.tsx
+++ b/apps/core-app/src/components/proposalCards/ReadyForProcessing.tsx
@@ -181,7 +181,7 @@ export const ReadyForProcessing = ({
             sm
             onClick={processProposal}
             className="execute"
-            rules={[isConnectedToDao, isNotLoading]}
+            rules={[isConnectedToDao, isNotLoading, canProcess]}
             centerAlign
             fullWidth={isMobile}
           >

--- a/apps/core-app/src/components/proposalCards/ReadyForProcessing.tsx
+++ b/apps/core-app/src/components/proposalCards/ReadyForProcessing.tsx
@@ -88,7 +88,8 @@ export const ReadyForProcessing = ({
 
   const processProposal = async () => {
     const { proposalId, proposalData, actionGasEstimate } = proposal;
-    const processingGasLimit = Number(actionGasEstimate) > 0 && 
+    const processingGasLimit =
+      Number(actionGasEstimate) > 0 &&
       Number(actionGasEstimate) + PROCESS_PROPOSAL_GAS_LIMIT_ADDITION;
 
     if (!proposalId) return;
@@ -97,10 +98,12 @@ export const ReadyForProcessing = ({
       tx: {
         ...ACTION_TX.PROCESS,
         staticArgs: [proposalId, proposalData],
-        // Usually a proposal actionGasEstimate === 0 when the safe vault takes longer to 
+        // Usually a proposal actionGasEstimate === 0 when the safe vault takes longer to
         // be indexed by the Gnosis API (a DAO was recently summonned)
         // In this case, do not override gasLimit
-        overrides: processingGasLimit ? { gasLimit: processingGasLimit.toFixed() } : {},
+        overrides: processingGasLimit
+          ? { gasLimit: processingGasLimit.toFixed() }
+          : {},
       } as TXLego,
       lifeCycleFns: {
         onTxError: (error) => {
@@ -178,7 +181,7 @@ export const ReadyForProcessing = ({
             sm
             onClick={processProposal}
             className="execute"
-            rules={[isConnectedToDao, isNotLoading, canProcess]}
+            rules={[isConnectedToDao, isNotLoading]}
             centerAlign
             fullWidth={isMobile}
           >

--- a/libs/common-utilities/src/utils/error.ts
+++ b/libs/common-utilities/src/utils/error.ts
@@ -1,8 +1,27 @@
 type HasMessage = { message: string };
+type HasReason = { reason: string };
+type GasEstimationError = {
+  reason: string;
+  code: string;
+  method: string;
+  stack: string;
+  message: string;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const isEthersError = (error: any): error is GasEstimationError =>
+  error?.reason !== undefined &&
+  error?.code !== undefined &&
+  error?.method !== undefined &&
+  error?.message !== undefined;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const hasMessage = (value: any): value is HasMessage =>
-  value.message !== undefined;
+  value?.message !== undefined;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const isReasonable = (value: any): value is HasReason =>
+  value?.reason !== undefined;
 
 export const handleErrorMessage = ({
   error,
@@ -11,6 +30,12 @@ export const handleErrorMessage = ({
   error: unknown;
   fallback?: string;
 }) => {
+  if (error instanceof Error && isEthersError(error)) {
+    return `Contact Error: ${error.reason}`;
+  }
+  if (isReasonable(error)) {
+    return `Error: ${error.reason}`;
+  }
   if (hasMessage(error)) {
     return error.message;
   }


### PR DESCRIPTION
## GitHub Issue

Fixes[https://github.com/HausDAO/daohaus-monorepo/issues/884]

## Changes

Turns those garbage ethers.js gas estimation errors into this: 
![Screenshot from 2022-09-29 13-51-45](https://user-images.githubusercontent.com/53406838/193142287-acc119f1-c629-46c8-8ceb-70a3993bdf56.png)


## Notes for later

I spent a bunch of time dealing with solutions that were a lot less clean. I'd like to share what I learned here for anyone else who has to deal with a libraries brutal custom error types.


Here are some of my learnings: 

- Errors do not follow a standard format in JS. 
- Logging errors will inevitably log a message string. 
- In the case of a metamask error, logging out a message is really useful because Metamask formats messages that come in from Web3 or Ethers
- However, Ethers alone is pretty brutal. It mixes gas estimation errors and contract errors into the same format. 
https://docs.ethers.io/v5/troubleshooting/errors/#help-UNPREDICTABLE_GAS_LIMIT
- Ethers message looks like a stack trace
- What we need is listed as "reason" inside this message blob of data. 
- Trying to hack regex to get that inside wasn't a great solution and was sort of unreliable
- Turns out that if we log an error with console.table(), we can see the data structure of an ethers error. 
- Turns out I can pull .reason from the error
- But first I have to get around TS by making a custom error type and typeguard 
- Then we get access to a .reason string that is the error message from the smart contract...what we wanted all along. 

## Next steps: 

- Because most of the errors in the baal contract are like '!baal', we need to map human readable errors to them
- However, I think some of the error strings are being reused, which would mess up mapping
- Best plan of action would be to use error codes or messages in the contract that are unique 

## Packages Added

NA

## Checks

Before making your PR, please check the following:

- [x] Critical lint errors are resolved
- [x] App runs locally
- [x] App builds locally (run the build command for *any impacted package* and check for any errors before the PR)
