### PR TITLE
add link to TxHash on action failed message

### DIFF
--- a/apps/core-app/src/components/proposalCards/ActionFailed.tsx
+++ b/apps/core-app/src/components/proposalCards/ActionFailed.tsx
@@ -1,7 +1,13 @@
 import { ITransformedProposal } from '@daohaus/dao-data';
+import styled from 'styled-components';
+import { ExplorerLink } from '@daohaus/daohaus-connect-feature';
 import { Italic, ParSm } from '@daohaus/ui';
 import { VotingBar } from '../VotingBar';
 import { ActionTemplate } from './ActionPrimitives';
+
+const Link = styled(ExplorerLink)`
+  font-size: inherit;
+`;
 
 export const ActionFailed = ({
   proposal,
@@ -16,8 +22,10 @@ export const ActionFailed = ({
       helperDisplay={
         <ParSm>
           <Italic>
-            The external contract interaction failed. See details for more
-            information."
+            The external contract interaction failed. See <Link
+              address={proposal.processTxHash}
+              type="tx">transaction details
+            </Link> for more information.
           </Italic>
         </ParSm>
       }

--- a/libs/daohaus-connect-feature/src/components/ExplorerLink/ExplorerLink.tsx
+++ b/libs/daohaus-connect-feature/src/components/ExplorerLink/ExplorerLink.tsx
@@ -44,6 +44,7 @@ export const ExplorerLink = ({
     <Link
       href={explorerLink}
       className={className}
+      Icon={Icon}
       rel="noopener noreferrer"
       linkType="external"
     >


### PR DESCRIPTION
## GitHub Issue

Closes #913 

## Changes

Updates Action Failed message to include an external link to the explorer hash of the processed Tx

## Packages Added

None

## Checks

Before making your PR, please check the following:

- [X] Critical lint errors are resolved
- [X] App runs locally
- [X] App builds locally (run the build command for *any impacted package* and check for any errors before the PR)
