### PR TITLE
feature/release-branch-10-2022

### DIFF
--- a/libs/abi-utilities/package.json
+++ b/libs/abi-utilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daohaus/abi-utilities",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "type": "commonjs",
   "homepage": "https://github.com/HausDAO/daohaus-monorepo#readme",
   "issues": "https://github.com/HausDAO/daohaus-monorepo/issues?q=is%3Aissue+is%3Aopen",

--- a/libs/contract-utilities/package.json
+++ b/libs/contract-utilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daohaus/contract-utilities",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Daohaus contract utilties for interacting with the Baal contracts",
   "type": "commonjs",
   "homepage": "https://github.com/HausDAO/daohaus-monorepo#readme",

--- a/libs/daohaus-connect-feature/package.json
+++ b/libs/daohaus-connect-feature/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daohaus/daohaus-connect-feature",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "main": "./daohaus-connect-feature.umd.js",
   "module": "./daohaus-connect-feature.es.js",
   "typings": "./src/index.d.ts",

--- a/libs/form-builder/package.json
+++ b/libs/form-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daohaus/haus-form-builder",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "main": "./form-builder.umd.js",
   "module": "./form-builder.es.js",
   "typings": "./src/index.d.ts",

--- a/libs/ui/package.json
+++ b/libs/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daohaus/ui",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "main": "./ui.umd.js",
   "module": "./ui.es.js",
   "typings": "./src/index.d.ts",


### PR DESCRIPTION
## GitHub Issue

Bumps packages for a release to NPM

We can then do https://github.com/HausDAO/daohaus-monorepo/pull/921 after updating develop.

## Changes

Bumps versions for ABI Utilities, Contract Utilities, DAOhaus Connect, Form Builder, and the UI Library.

## Packages Added

N/a
