### PR TITLE
upgrading semver and adding ci task for opening pr

### DIFF
--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -70,5 +70,11 @@ jobs:
           BRANCH="bump-lib-versions-${CURRENT_DATE}"
           git checkout -b "${BRANCH}"
           git push -f --set-upstream origin "${BRANCH}"
+
+          gh pr view ${BRANCH}
+
+          if [ $? -ne 0 ]; then
+            gh pr create -t "update package versions" -b "update package versions to ${LAST_VERSION}."
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -72,9 +72,5 @@ jobs:
           git push -f --set-upstream origin "${BRANCH}"
 
           gh pr view ${BRANCH}
-
-          if [ $? -ne 0 ]; then
-            gh pr create -t "update package versions" -b "update package versions to ${LAST_VERSION}."
-          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -70,7 +70,5 @@ jobs:
           BRANCH="bump-lib-versions-${CURRENT_DATE}"
           git checkout -b "${BRANCH}"
           git push -f --set-upstream origin "${BRANCH}"
-
-          gh pr view ${BRANCH}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "@graphql-codegen/typescript": "^2.4.8",
     "@graphql-codegen/typescript-operations": "^2.3.5",
     "@graphql-typed-document-node/core": "^3.1.1",
-    "@jscutlery/semver": "^2.26.0",
+    "@jscutlery/semver": "^2.27.1",
     "@nrwl/cli": "14.4.3",
     "@nrwl/cypress": "14.4.3",
     "@nrwl/devkit": "^14.4.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3138,10 +3138,10 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@jscutlery/semver@^2.26.0":
-  version "2.26.0"
-  resolved "https://registry.yarnpkg.com/@jscutlery/semver/-/semver-2.26.0.tgz#15cb627a713ef3a4e2564a04ab5f01e5cc534d7c"
-  integrity sha512-4LjgXPM2V1xTOWCjPQerbjljKdnTi7pCmeC5jfRdDe7ZkKH2Fs+MBqEeblrvzCM2hHG28UOq0bKw0ibUg8nA3A==
+"@jscutlery/semver@^2.27.1":
+  version "2.27.1"
+  resolved "https://registry.yarnpkg.com/@jscutlery/semver/-/semver-2.27.1.tgz#d1979cc21cd92094b6f47fbae1642fcf052a7be7"
+  integrity sha512-uApRqj8Pc2CG9BbN/ZiWFz9xNq14XDueJZQnhsdO0B9CYoAZqCEoKLbToM7yRXkQ/ZRg7uV3xkrFYEWXVl1K8Q==
   dependencies:
     detect-indent "6.1.0"
     inquirer "8.2.4"


### PR DESCRIPTION
## GitHub Issue

upgrading semver

## Changes

updating semver - skips merge commits and unrelated histories now

https://github.com/jscutlery/semver/commit/188ed4c1e7511dbfdce207b497045b4c74394316#diff-1c35e67313868181977db1f5737adf447a8f69007428f5fd7fc0582f87f717feR216

## Packages Added

@jscutlery/semver 2.27.1

## Checks

Before making your PR, please check the following:

- [ ] Critical lint errors are resolved
- [ ] App runs locally
- [ ] App builds locally (run the build command for *any impacted package* and check for any errors before the PR)
