### PR TITLE
increase default gasLimit for cases where actionGasEstimate is zero

### DIFF
--- a/apps/core-app/src/components/proposalCards/ReadyForProcessing.tsx
+++ b/apps/core-app/src/components/proposalCards/ReadyForProcessing.tsx
@@ -94,7 +94,7 @@ export const ReadyForProcessing = ({
     const processingGasLimit = (
       Number(actionGasEstimate) > 0
         ? Number(actionGasEstimate) + PROCESS_PROPOSAL_GAS_LIMIT_ADDITION
-        : PROCESS_PROPOSAL_GAS_LIMIT_ADDITION * 2
+        : PROCESS_PROPOSAL_GAS_LIMIT_ADDITION * 3.6
     ).toFixed();
 
     if (!proposalId) return;


### PR DESCRIPTION
## GitHub Issue

#952 

## Changes

A summary of the changes in the code in this PR. If making any UI changes consider adding screenshots or gifs.

## Packages Added

Increase default gas limit used for processing proposals that failed to estimate gas (actionGasEstimate = 0)

## Checks

Before making your PR, please check the following:

- [X] Critical lint errors are resolved
- [X] App runs locally
- [X] App builds locally (run the build command for *any impacted package* and check for any errors before the PR)
