### PR TITLE
Use tx metadata to parse abi encoded params

### DIFF
--- a/apps/core-app/src/components/ActionDisplay.tsx
+++ b/apps/core-app/src/components/ActionDisplay.tsx
@@ -130,7 +130,10 @@ const ValueDisplay = ({
         {argValue.map((value, index) => {
           return (
             <div className="space" key={`argValue${index}`}>
-              <ValueDisplay argValue={value} network={network} />
+              <ValueDisplay
+                argValue={Array.isArray(value) ? `${value[0]}: ${value[1]}` : value}
+                network={network}
+              />
               {index + 1 < argValue?.length && <Divider />}
             </div>
           );

--- a/apps/core-app/src/pages/ProposalDetails.tsx
+++ b/apps/core-app/src/pages/ProposalDetails.tsx
@@ -12,6 +12,7 @@ import { ITransformedProposalQuery } from '@daohaus/dao-data';
 import {
   isValidNetwork,
   Keychain,
+  MulticallArg,
   ValidNetwork,
 } from '@daohaus/common-utilities';
 import { useHausConnect } from '@daohaus/daohaus-connect-feature';
@@ -27,6 +28,7 @@ import {
   decodeProposalActions,
 } from '@daohaus/tx-builder-feature';
 import { ActionDisplay } from '../components/ActionDisplay';
+import { TX } from '../legos/tx';
 
 // generate a random hex string that is 900 characters long
 
@@ -94,11 +96,14 @@ export function ProposalDetails() {
     let shouldUpdate = true;
     const fetchPropActions = async (
       chainId: ValidNetwork,
-      actionData: string
+      actionData: string,
+      proposalType: string,
     ) => {
+      const multicallMeta = TX[proposalType]?.args?.find(tx => (tx as MulticallArg).type === 'multicall');
       const proposalActions = await decodeProposalActions({
         chainId,
         actionData,
+        actionsMeta: multicallMeta && (multicallMeta as MulticallArg).actions,
       });
       if (shouldUpdate) {
         setActionData(proposalActions);
@@ -106,7 +111,7 @@ export function ProposalDetails() {
     };
 
     if (!isValidNetwork(daochain) || !proposal) return;
-    fetchPropActions(daochain, proposal.proposalData);
+    fetchPropActions(daochain, proposal.proposalData, proposal.proposalType);
 
     return () => {
       shouldUpdate = false;

--- a/libs/tx-builder-feature/src/utils/decoding.ts
+++ b/libs/tx-builder-feature/src/utils/decoding.ts
@@ -114,6 +114,7 @@ const buildEthTransferAction = (action: EncodedAction): DecodedAction => ({
   params: [],
 });
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const decodeParam = ({
   argMeta,
   value,


### PR DESCRIPTION
## GitHub Issue

Closes #942 

## Changes

Use tx lego metadata to parse ABI encoded params. For example, Baal governance config params are sent as ABI-encoded bytes

## Packages Added

None

## Checks

Before making your PR, please check the following:

- [X] Critical lint errors are resolved
- [X] App runs locally
- [X] App builds locally (run the build command for *any impacted package* and check for any errors before the PR)
