### PR TITLE
Add warning styling for sensitive contract call actions

### DIFF
--- a/apps/core-app/src/components/ProposalCardOverview.tsx
+++ b/apps/core-app/src/components/ProposalCardOverview.tsx
@@ -1,5 +1,13 @@
+import { RiErrorWarningLine, RiTimeLine } from 'react-icons/ri';
 import { useParams } from 'react-router-dom';
 import styled, { useTheme } from 'styled-components';
+import {
+  charLimit,
+  formatShortDateTimeFromSeconds,
+  Keychain,
+} from '@daohaus/common-utilities';
+import { TProposals } from '@daohaus/dao-context';
+import { ITransformedProposal } from '@daohaus/dao-data';
 import {
   AddressDisplay,
   Button,
@@ -10,17 +18,12 @@ import {
   widthQuery,
   Tooltip,
   ParSm,
+  Theme,
+  Icon,
 } from '@daohaus/ui';
-import {
-  charLimit,
-  formatShortDateTimeFromSeconds,
-  Keychain,
-} from '@daohaus/common-utilities';
 
-import { TProposals } from '@daohaus/dao-context';
 import { getProposalTypeLabel } from '../utils/general';
-import { ITransformedProposal } from '@daohaus/dao-data';
-import { RiTimeLine } from 'react-icons/ri';
+import { SENSITIVE_PROPOSAL_TYPES } from '../utils/constants';
 
 const OverviewBox = styled.div`
   display: flex;
@@ -112,6 +115,22 @@ const OverviewContainer = styled.div`
   }
 `;
 
+const HeaderContainer = styled.div`
+  display: flex;
+`;
+
+const StyledPropType = styled.span`
+  color: ${({ theme, warning }: { theme: Theme; warning: boolean; }) =>
+    warning && theme.warning.step9};
+`;
+
+const WarningIcon = styled(RiErrorWarningLine)`
+  color: ${({ theme }: { theme: Theme; }) => theme.warning.step9};
+  height: 2rem;
+  width: 2rem;
+  margin-right: 0.5rem;
+`
+
 export const OverviewHeader = ({
   proposal,
 }: {
@@ -125,9 +144,19 @@ export const OverviewHeader = ({
     <OverviewContainer>
       {isMobile ? (
         <>
-          <ParSm color={theme.secondary.step11}>
-            {getProposalTypeLabel(proposal.proposalType)}
-          </ParSm>
+          <HeaderContainer>
+            {SENSITIVE_PROPOSAL_TYPES[proposal.proposalType] && (
+              <Icon label='Warning'><WarningIcon /></Icon>
+            )}
+            <ParSm color={
+              SENSITIVE_PROPOSAL_TYPES[proposal.proposalType]
+                ? theme.warning.step9
+                : theme.secondary.step11
+              }
+            >
+              {getProposalTypeLabel(proposal.proposalType)}
+            </ParSm>
+          </HeaderContainer>
           <Tooltip
             content={formatShortDateTimeFromSeconds(proposal.createdAt)}
             triggerEl={
@@ -137,10 +166,17 @@ export const OverviewHeader = ({
         </>
       ) : (
         <>
-          <ParSm color={theme.secondary.step11}>
-            {getProposalTypeLabel(proposal.proposalType)} |{' '}
-            {formatShortDateTimeFromSeconds(proposal.createdAt)}
-          </ParSm>
+          <HeaderContainer>
+            {SENSITIVE_PROPOSAL_TYPES[proposal.proposalType] && (
+              <Icon label='Warning'><WarningIcon /></Icon>
+            )}
+            <ParSm color={theme.secondary.step11}>
+              <StyledPropType warning={SENSITIVE_PROPOSAL_TYPES[proposal.proposalType]}>
+                {getProposalTypeLabel(proposal.proposalType)}
+              </StyledPropType> |{' '}
+              {formatShortDateTimeFromSeconds(proposal.createdAt)}
+            </ParSm>
+          </HeaderContainer>
           <StyledLink
             href={`/molochV3/${daochain}/${daoid}/proposals/${proposal.proposalId}`}
           >

--- a/apps/core-app/src/components/ProposalWarning.tsx
+++ b/apps/core-app/src/components/ProposalWarning.tsx
@@ -4,7 +4,10 @@ import styled from 'styled-components';
 import { ExplorerLink } from '@daohaus/daohaus-connect-feature';
 import { Card, Icon, ParXs, Theme } from '@daohaus/ui';
 
-import { PROPOSAL_TYPE_WARNINGS } from '../utils/constants';
+import {
+  PROPOSAL_TYPE_WARNINGS,
+  SENSITIVE_PROPOSAL_TYPES,
+} from '../utils/constants';
 
 const WarningContainer = styled(Card)`
   display: flex;
@@ -61,6 +64,7 @@ export const ProposalWarning = ({
 
   const hasWarning =
     decodeError ||
+    (proposalType && SENSITIVE_PROPOSAL_TYPES[proposalType]) ||
     warningMessage === PROPOSAL_TYPE_WARNINGS.ERROR_UNKOWN;
 
   // TODO: activate this feature when errors use cases arise

--- a/apps/core-app/src/utils/constants.ts
+++ b/apps/core-app/src/utils/constants.ts
@@ -61,3 +61,11 @@ export const PROPOSAL_TYPE_WARNINGS: { [key: string]: string } = {
   ERROR_UNKOWN:
     'We can’t verify the contract details for this proposal. Please proceed with extreme caution!',
 };
+
+export const SENSITIVE_PROPOSAL_TYPES: { [key: string]: boolean } = {
+  ADD_SHAMAN: true,
+};
+
+export const DAO_METHOD_TO_PROPOSAL_TYPE: { [key: string]: string } = {
+  'setShamans': ProposalTypeIds.AddShaman,
+};


### PR DESCRIPTION
## GitHub Issue

Closes #958 

## Changes

Adds a warning label for proposal types & warning message display for proposals calling sensitive contract call actions like Baal `setShaman`. This message will be displayed at a) the proposal level or b) the action level in case "actionType" is different than proposalType (e.g. calling `setShaman` action from a tx builder proposal)

## Packages Added

None

## Checks

Before making your PR, please check the following:

- [X] Critical lint errors are resolved
- [X] App runs locally
- [X] App builds locally (run the build command for *any impacted package* and check for any errors before the PR)
