### PR TITLE
Add tx lifecycle overrides for proposal action execution

### DIFF
--- a/apps/core-app/src/components/ProposalCardOverview.tsx
+++ b/apps/core-app/src/components/ProposalCardOverview.tsx
@@ -62,10 +62,12 @@ const StyledLink = styled(Link)`
 `;
 
 type ProposalCardOverviewProps = {
+  loading: boolean;
   proposal: TProposals[number];
 };
 
 export const ProposalCardOverview = ({
+  loading,
   proposal,
 }: ProposalCardOverviewProps) => {
   const { daochain, daoid } = useParams();
@@ -75,16 +77,16 @@ export const ProposalCardOverview = ({
 
   return (
     <OverviewBox>
-      <OverviewHeader proposal={proposal} />
+      <OverviewHeader loading={loading} proposal={proposal} />
       <ParLg className="title">{proposal.title}</ParLg>
       <ParMd className="description" color={theme.secondary.step11}>
         {charLimit(proposal.description, 145)}
       </ParMd>
       {isMd && (
         <StyledLink
-          href={`/molochV3/${daochain}/${daoid}/proposals/${proposal.proposalId}`}
+          href={!loading ? `/molochV3/${daochain}/${daoid}/proposals/${proposal.proposalId}` : '#'}
         >
-          <Button secondary sm fullWidth={isMobile} centerAlign>
+          <Button disabled={loading} secondary sm fullWidth={isMobile} centerAlign>
             View Details
           </Button>
         </StyledLink>
@@ -132,8 +134,10 @@ const WarningIcon = styled(RiErrorWarningLine)`
 `
 
 export const OverviewHeader = ({
+  loading,
   proposal,
 }: {
+  loading: boolean;
   proposal: ITransformedProposal;
 }) => {
   const { daochain, daoid } = useParams();
@@ -178,9 +182,9 @@ export const OverviewHeader = ({
             </ParSm>
           </HeaderContainer>
           <StyledLink
-            href={`/molochV3/${daochain}/${daoid}/proposals/${proposal.proposalId}`}
+            href={!loading ? `/molochV3/${daochain}/${daoid}/proposals/${proposal.proposalId}` : '#'}
           >
-            <Button secondary sm>
+            <Button disabled={loading} secondary sm>
               View Details
             </Button>
           </StyledLink>

--- a/apps/core-app/src/components/proposalCards/BaseProposalCard.tsx
+++ b/apps/core-app/src/components/proposalCards/BaseProposalCard.tsx
@@ -1,9 +1,11 @@
+import { useState } from 'react';
 import styled from 'styled-components';
 import { Card, widthQuery } from '@daohaus/ui';
 
 import { ProposalCardOverview } from '../ProposalCardOverview';
 import { ProposalActions } from './ProposalActions';
 import { ITransformedProposal } from '@daohaus/dao-data';
+import { ActionLifeCycleFns } from '../../utils/general';
 
 const ProposalCardContainer = styled(Card)`
   display: flex;
@@ -46,13 +48,29 @@ type BaseProposalCardProps = {
 };
 
 export const BaseProposalCard = ({ proposal }: BaseProposalCardProps) => {
+
+  const [actionLoading, setActionLoading] = useState<boolean>(false);
+
+  const lifeCycleFnsOverride: ActionLifeCycleFns = {
+    onActionTriggered: () => setActionLoading(true),
+    onPollError: () => setActionLoading(false),
+    onPollSuccess: () => setActionLoading(false),
+    onTxError: () => setActionLoading(false),
+  };
+
   return (
     <ProposalCardContainer>
       <LeftCard>
-        <ProposalCardOverview proposal={proposal} />
+        <ProposalCardOverview
+          loading={actionLoading}
+          proposal={proposal}
+        />
       </LeftCard>
       <RightCard>
-        <ProposalActions proposal={proposal} />
+        <ProposalActions
+          lifeCycleFnsOverride={lifeCycleFnsOverride}
+          proposal={proposal}
+        />
       </RightCard>
     </ProposalCardContainer>
   );

--- a/apps/core-app/src/components/proposalCards/ProposalActions.tsx
+++ b/apps/core-app/src/components/proposalCards/ProposalActions.tsx
@@ -2,6 +2,7 @@ import { PROPOSAL_STATUS } from '@daohaus/common-utilities';
 import { ITransformedProposal } from '@daohaus/dao-data';
 import { ParMd, widthQuery } from '@daohaus/ui';
 import styled from 'styled-components';
+import { ActionLifeCycleFns } from '../../utils/general';
 import { ActionFailed } from './ActionFailed';
 import { ActionTemplate } from './ActionPrimitives';
 import { Cancelled } from './Cancelled';
@@ -25,8 +26,10 @@ const ActionBox = styled.div`
 `;
 
 export const ProposalActions = ({
+  lifeCycleFnsOverride,
   proposal,
 }: {
+  lifeCycleFnsOverride?: ActionLifeCycleFns;
   proposal: ITransformedProposal;
 }) => {
   if (proposal.status === PROPOSAL_STATUS.cancelled) {
@@ -39,14 +42,20 @@ export const ProposalActions = ({
   if (proposal.status === PROPOSAL_STATUS.unsponsored) {
     return (
       <ActionBox>
-        <Unsponsored proposal={proposal} />
+        <Unsponsored
+          lifeCycleFnsOverride={lifeCycleFnsOverride}
+          proposal={proposal}
+        />
       </ActionBox>
     );
   }
   if (proposal.status === PROPOSAL_STATUS.voting) {
     return (
       <ActionBox>
-        <VotingPeriod proposal={proposal} />
+        <VotingPeriod
+          lifeCycleFnsOverride={lifeCycleFnsOverride}
+          proposal={proposal}
+        />
       </ActionBox>
     );
   }
@@ -60,7 +69,10 @@ export const ProposalActions = ({
   if (proposal.status === PROPOSAL_STATUS.needsProcessing) {
     return (
       <ActionBox>
-        <ReadyForProcessing proposal={proposal} />
+        <ReadyForProcessing
+          lifeCycleFnsOverride={lifeCycleFnsOverride}
+          proposal={proposal}
+        />
       </ActionBox>
     );
   }

--- a/apps/core-app/src/components/proposalCards/VotingPeriod.tsx
+++ b/apps/core-app/src/components/proposalCards/VotingPeriod.tsx
@@ -6,10 +6,13 @@ import { useHausConnect } from '@daohaus/daohaus-connect-feature';
 
 import { HasVoted } from './HasVoted';
 import { HasNotVoted } from './HasNotVoted';
+import { ActionLifeCycleFns } from '../../utils/general';
 
 export const VotingPeriod = ({
+  lifeCycleFnsOverride,
   proposal,
 }: {
+  lifeCycleFnsOverride?: ActionLifeCycleFns;
   proposal: ITransformedProposal;
 }) => {
   const { address } = useHausConnect();
@@ -35,6 +38,10 @@ export const VotingPeriod = ({
       userVoteBalance={userVoteData?.balance}
     />
   ) : (
-    <HasNotVoted proposal={proposal} readableTime={readableTime} />
+    <HasNotVoted
+      lifeCycleFnsOverride={lifeCycleFnsOverride}
+      proposal={proposal}
+      readableTime={readableTime}
+    />
   );
 };

--- a/apps/core-app/src/pages/ProposalDetails.tsx
+++ b/apps/core-app/src/pages/ProposalDetails.tsx
@@ -20,7 +20,7 @@ import { useHausConnect } from '@daohaus/daohaus-connect-feature';
 import { loadProposal } from '../utils/dataFetchHelpers';
 import { ProposalDetailsGuts } from '../components/ProposalDetailsGuts';
 import { ProposalHistory } from '../components/ProposalHistory';
-import { getProposalTypeLabel } from '../utils/general';
+import { ActionLifeCycleFns, getProposalTypeLabel } from '../utils/general';
 import { ProposalActions } from '../components/proposalCards/ProposalActions';
 import { CancelProposal } from '../components/CancelProposal';
 import {
@@ -121,6 +121,10 @@ export function ProposalDetails() {
     };
   }, [daochain, proposal]);
 
+  const lifeCycleFnsOverride: ActionLifeCycleFns = {
+    onPollSuccess: () => fetchProposal(),
+  };
+
   if (proposalLoading) {
     return (
       <SingleColumnLayout>
@@ -148,14 +152,22 @@ export function ProposalDetails() {
           }
           {actionData && (
             <ActionContainer>
-              <ActionDisplay actions={actionData} />
+              <ActionDisplay
+                actions={actionData}
+                proposalType={proposal?.proposalType}
+              />
             </ActionContainer>
           )}
         </OverviewCard>
       }
       right={
         <RightCard>
-          {proposal && <ProposalActions proposal={proposal} />}
+          {proposal && (
+            <ProposalActions
+              lifeCycleFnsOverride={lifeCycleFnsOverride}
+              proposal={proposal}
+            />
+          )}
           <ProposalHistory proposal={proposal} />
         </RightCard>
       }

--- a/apps/core-app/src/utils/general.ts
+++ b/apps/core-app/src/utils/general.ts
@@ -1,5 +1,10 @@
 import { TDao, TMembers } from '@daohaus/dao-context';
+import { TXLifeCycleFns } from '@daohaus/tx-builder-feature';
 import { PROPOSAL_TYPE_LABELS } from './constants';
+
+export type ActionLifeCycleFns = TXLifeCycleFns & {
+  onActionTriggered?: () => void;
+}
 
 export const missingDaoProfileData = (dao: TDao): boolean => {
   if (!dao?.profile || !dao.profile.length) return true;


### PR DESCRIPTION
## GitHub Issue

Closes #972 
Closes #918 

## Changes

Adds tx events methods that can override the default proposal action execution lifecycle so UI can properly fetch & display the latest state of a proposal

## Packages Added

None

## Checks

Before making your PR, please check the following:

- [X] Critical lint errors are resolved
- [X] App runs locally
- [X] App builds locally (run the build command for *any impacted package* and check for any errors before the PR)
